### PR TITLE
bump node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8214,6 +8214,11 @@
         "tslib": "^1.10.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-forge": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "kind-of": "^6.0.3",
     "mem": "^5.1.1",
     "minimist": "^1.2.5",
+    "node-fetch": "^2.6.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-dropdown-date": "0.0.14",


### PR DESCRIPTION
# Description
Details
GHSA-w7rc-rwvf-8q5r
low severity
Vulnerable versions: < 2.6.1
Patched version: 2.6.1


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
